### PR TITLE
fixed bug with multiple high precedent operators

### DIFF
--- a/src/main/sep_example.c
+++ b/src/main/sep_example.c
@@ -3,7 +3,7 @@
 
 int main(void)
 {
-    float result = sep_parse("10-5+8*4-2");
+    float result = sep_parse("10-5+2*4-3*3/2*5/2+5*2-3/6*3");
     printf("%f\n", result);
     return 0;
 }

--- a/src/main/simple_expression_parser.c
+++ b/src/main/simple_expression_parser.c
@@ -94,7 +94,8 @@ static void compute_high_precedence_operators(token* _token)
             temp->next_token = temp->next_token->next_token;
             free(free_token);
         }
-        temp = temp->next_token;
+        else
+            temp = temp->next_token;
     }
 }
 
@@ -102,6 +103,7 @@ static float evaluate_final_expression(token* _token)
 {
     token* temp = _token;
     float result = temp->value;
+    printf("CURRENT VALUE: %f\n", result);
     while (temp != NULL)
     {
         switch(temp->operator)
@@ -119,6 +121,7 @@ static float evaluate_final_expression(token* _token)
                 result /= temp->next_token->value;
                 break;
         }
+        printf("CURRENT VALUE: %f\n", result);
         temp = temp->next_token;
     }
     return result;


### PR DESCRIPTION
if you have multiple high precendent operators (e.g. * and /) it was traversing to the next node too early which skips a necessary computation and then results are evaluated in the incorrect order leading to inaccurate results